### PR TITLE
Allow risky fixers with `allow_risky` setting

### DIFF
--- a/SublimePhpCsFixer.py
+++ b/SublimePhpCsFixer.py
@@ -174,6 +174,7 @@ class FixerProcess:
     def create_cmd(self, tmp_file):
         config = self.config_param()
         rules = self.rules_param()
+        allow_risky = self.allow_risky_param()
 
         if rules and config:
             self.logger.console("rules and config are both present, rules prevails")
@@ -185,6 +186,7 @@ class FixerProcess:
             "fix",
             rules,
             config,
+            allow_risky,
             "--using-cache=no",
             tmp_file,
         ]))
@@ -225,6 +227,12 @@ class FixerProcess:
             self.logger.console("Using rules: " + rules)
             return "--rules=" + rules
 
+        return None
+
+    def allow_risky_param(self):
+        if self.settings.get("allow_risky"):
+            return "--allow-risky=yes"
+        
         return None
 
     def get_configured_php_cs_fixer_path(self):


### PR DESCRIPTION
By default PHP-CS-Fixer won’t run if you have "risky" rules in your config.

I added a setting named `allow_risky` to opt-in by adding the `--allow-risky=yes` param to the command.